### PR TITLE
fix(regexp): make it work with json strings that include quotes

### DIFF
--- a/test.js
+++ b/test.js
@@ -12,4 +12,5 @@ it('should convert matching double-quotes to single-quotes', function () {
 	assert.equal(s('bar "foo" baz'), 'bar \'foo\' baz');
 	assert.equal(s('\'bar\' "foo" \'baz\''), '\'bar\' \'foo\' \'baz\'');
 	assert.equal(s('\\\"foo\\\"'), '\'foo\'');
+	assert.equal(s(JSON.stringify({'a': '<a href="addr">'})), '{\'a\':\'<a href="addr">\'}');
 });

--- a/to-single-quotes.js
+++ b/to-single-quotes.js
@@ -8,7 +8,7 @@
 (function () {
 	'use strict';
 	var toSingleQuotes = function (str) {
-		return str.replace(/(?:\\*)?"[^"]*"/g, function (match) {
+		return str.replace(/(?:\\*)?"([^"\\]*\\")*[^"]*"/g, function (match) {
 			return match
 				.replace(/\\"/g, '"')            // unescape double-quotes
 				.replace(/([^\\])'/g, '$1\\\'')  // escape single-quotes


### PR DESCRIPTION
Hi, I'm using this module as a method to get JSON.stringify with single quotes. It works great, but there is one problem with stuff like this:`{"a": "<a href=\"addr\">"}` because of the escaped double quotes inside the string. It seems you intended to handle this by unescaping double-quotes, but there was a problem with the top regexp that extracts string expression. What do you think? Does this make sense?
