### PR TITLE
Fix escaping bug for two consecutive apostrophes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 module.exports = function (str) {
-  function escapeIfNotPrecededByEscapeChar(escapeChar, match, offset, string) { return string[offset - 1] === escapeChar ? match : escapeChar + match;}
+	function escapeIfNotPrecededByEscapeChar(escapeChar, match, offset, string) { return string[offset - 1] === escapeChar ? match : escapeChar + match;}
 	return str.replace(/(?:\\*)?"([^"\\]*\\.)*[^"]*"/g, function (match) {
 		return match
 			.replace(/\\"/g, '"')            // unescape double-quotes

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 'use strict';
 module.exports = function (str) {
+  function escapeIfNotPrecededByEscapeChar(escapeChar, match, offset, string) { return string[offset - 1] === escapeChar ? match : escapeChar + match;}
 	return str.replace(/(?:\\*)?"([^"\\]*\\.)*[^"]*"/g, function (match) {
 		return match
 			.replace(/\\"/g, '"')            // unescape double-quotes
-			.replace(/([^\\])'/g, '$1\\\'')  // escape single-quotes
+			.replace(/'/g, escapeIfNotPrecededByEscapeChar.bind(null, '\\'))
 			.replace(/^"|"$/g, '\'');        // convert
 	});
 };

--- a/test.js
+++ b/test.js
@@ -14,4 +14,5 @@ it('should convert matching double-quotes to single-quotes', function () {
 	assert.equal(s('\\\"foo\\\"'), '\'foo\'');
 	assert.equal(s(JSON.stringify({'a': '<a href="addr">'})), '{\'a\':\'<a href="addr">\'}');
 	assert.equal(s(JSON.stringify({'a': 'aa\n<a href="addr">'})), '{\'a\':\'aa\\n<a href="addr">\'}');
+  assert.equal(s(JSON.stringify({"a": "b''c" })), "{'a':'b\'\'c'}");
 });

--- a/test.js
+++ b/test.js
@@ -14,5 +14,5 @@ it('should convert matching double-quotes to single-quotes', function () {
 	assert.equal(s('\\\"foo\\\"'), '\'foo\'');
 	assert.equal(s(JSON.stringify({'a': '<a href="addr">'})), '{\'a\':\'<a href="addr">\'}');
 	assert.equal(s(JSON.stringify({'a': 'aa\n<a href="addr">'})), '{\'a\':\'aa\\n<a href="addr">\'}');
-  assert.equal(s(JSON.stringify({"a": "b''c" })), "{'a':'b\'\'c'}");
+  	assert.equal(s(JSON.stringify({"a": "b''c" })), "{'a':'b\'\'c'}");
 });


### PR DESCRIPTION
when two consecutive apostrophes were used, only the first apostrophe was escaped (last test is an example for such input). now fixed.