### PR TITLE
Use string processing instead of regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,18 +3,48 @@ module.exports = function (str) {
 	var result = "";
 	var x, y, len = str.length;
 	var betweenQuotes = false;
+	var QuoteChar;
 	for(x = 0; x < len; x++) {
+		//FOUND DOUBLE-QUOTE OR SINGLE-QUOTE
 		if(str[x] === '"' || str[x] === '\'') {
-
+			//IF NOT PROCESSING IN BETWEEN QUOTES
 			if(!betweenQuotes) {
+				QuoteChar = str[x];
 				betweenQuotes = true;
 				result+= '\'';
 			}
+			//IF PROCESSING IN BETWEEN QUOTES
 			else {
+				//CLOSE QUOTES
+				if(QuoteChar == str[x]) {
 					result+= '\'';
-				betweenQuotes = false;
+					betweenQuotes = false;
+				}
+				//STILL INSIDE QUOTES
+				else
+					result+= '\\\'';
 			}
 
+		}
+		//IF ESCAPE CHARACTER IS FOUND AND DOUBLE OR SINGLE QUOTE AFTER
+		else if(str[x] === '\\' && (str[x+1] === '\'' || str[x+1] === '"')) {
+			//ESCAPE + SINGLE QUOTE
+			if(str[x+1] === '\'') {
+				result+= '\\\\\'';
+				x++;
+			}
+			//ESCAPE + DOUBLE QUOTE
+			else if(str[x+1] === '"') {
+				result+= '"';
+				x++;
+			}
+			else
+				result+= str[x];
+		}
+		//BACKSLASHES --> DON'T TOUCHE THEM
+		else if(str[x] === '\\' && str[x+1] === '\\') {
+			result+='\\\\';
+			x++;
 		}
 		else
 			result+= str[x];

--- a/index.js
+++ b/index.js
@@ -1,16 +1,23 @@
 'use strict';
 module.exports = function (str) {
-	return str.replace(/(?:\\*)?"([^"\\]*\\.)*[^"]*"/g, function (match) {
-		return match
-			// unescape double-quotes
-			.replace(/([^\\]|^)\\"/g, '$1"')
-			// escape escapes
-			.replace(/(^|[^\\])(\\+)'/g, '$1$2\\\'')
-			// escape single-quotes - round 1
-			.replace(/([^\\])'/g, '$1\\\'')
-			// escape single-quotes - round 2 (for consecutive single-quotes)
-			.replace(/([^\\])'/g, '$1\\\'')
-			// convert
-			.replace(/^"|"$/g, '\'');
-	});
+	var result = "";
+	var x, y, len = str.length;
+	var betweenQuotes = false;
+	for(x = 0; x < len; x++) {
+		if(str[x] === '"' || str[x] === '\'') {
+
+			if(!betweenQuotes) {
+				betweenQuotes = true;
+				result+= '\'';
+			}
+			else {
+					result+= '\'';
+				betweenQuotes = false;
+			}
+
+		}
+		else
+			result+= str[x];
+	}
+	return result;
 };

--- a/index.js
+++ b/index.js
@@ -4,42 +4,42 @@ module.exports = function (str) {
 	var x;
 	var len = str.length;
 	var betweenQuotes = false;
-	var QuoteChar;
+	var quoteChar;
 	for (x = 0; x < len; x++) {
-		// FOUND DOUBLE-QUOTE OR SINGLE-QUOTE
+		// found double-quote or single-quote
 		if (str[x] === '"' || str[x] === '\'') {
-			// IF NOT PROCESSING IN BETWEEN QUOTES
-			if (betweenQuotes === false) {
-				QuoteChar = str[x];
+			// if not processing in between quotes
+			if (!betweenQuotes) {
+				quoteChar = str[x];
 				betweenQuotes = true;
 				result += '\'';
-			} else if (QuoteChar === str[x]) {
-				// IF PROCESSING IN BETWEEN QUOTES
-				// CLOSE QUOTES
+			} else if (quoteChar === str[x]) {
+				// if processing between quotes
+				// close quotes
 				result += '\'';
 				betweenQuotes = false;
-			}	else {
-					// STILL INSIDE QUOTES
+			} else {
+				// still inside quotes
 				result += '\\\'';
 			}
 		} else if (str[x] === '\\' && (str[x + 1] === '\'' || str[x + 1] === '"')) {
-			// IF ESCAPE CHARACTER IS FOUND AND DOUBLE OR SINGLE QUOTE AFTER
-			// ESCAPE + SINGLE QUOTE
+			// if escape character is found and double or single quote after
+			// escape + single-quote
 			if (str[x + 1] === '\'') {
 				result += '\\\\\'';
 				x++;
 			} else if (str[x + 1] === '"') {
-				// ESCAPE + DOUBLE QUOTE
+				// escape + double-quote
 				result += '"';
 				x++;
-			}			else				{
+			} else {
 				result += str[x];
 			}
-		}		else if (str[x] === '\\' && str[x + 1] === '\\') {
-			// BACKSLASHES --> DON'T TOUCHE THEM
+		} else if (str[x] === '\\' && str[x + 1] === '\\') {
+			// backslashes --> don't touch them
 			result += '\\\\';
 			x++;
-		}		else			{
+		} else {
 			result += str[x];
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -1,53 +1,47 @@
 'use strict';
 module.exports = function (str) {
-	var result = "";
-	var x, y, len = str.length;
+	var result = '';
+	var x;
+	var len = str.length;
 	var betweenQuotes = false;
 	var QuoteChar;
-	for(x = 0; x < len; x++) {
-		//FOUND DOUBLE-QUOTE OR SINGLE-QUOTE
-		if(str[x] === '"' || str[x] === '\'') {
-			//IF NOT PROCESSING IN BETWEEN QUOTES
-			if(!betweenQuotes) {
+	for (x = 0; x < len; x++) {
+		// FOUND DOUBLE-QUOTE OR SINGLE-QUOTE
+		if (str[x] === '"' || str[x] === '\'') {
+			// IF NOT PROCESSING IN BETWEEN QUOTES
+			if (betweenQuotes === false) {
 				QuoteChar = str[x];
 				betweenQuotes = true;
-				result+= '\'';
+				result += '\'';
+			} else if (QuoteChar === str[x]) {
+				// IF PROCESSING IN BETWEEN QUOTES
+				// CLOSE QUOTES
+				result += '\'';
+				betweenQuotes = false;
+			}	else {
+					// STILL INSIDE QUOTES
+				result += '\\\'';
 			}
-			//IF PROCESSING IN BETWEEN QUOTES
-			else {
-				//CLOSE QUOTES
-				if(QuoteChar == str[x]) {
-					result+= '\'';
-					betweenQuotes = false;
-				}
-				//STILL INSIDE QUOTES
-				else
-					result+= '\\\'';
-			}
-
-		}
-		//IF ESCAPE CHARACTER IS FOUND AND DOUBLE OR SINGLE QUOTE AFTER
-		else if(str[x] === '\\' && (str[x+1] === '\'' || str[x+1] === '"')) {
-			//ESCAPE + SINGLE QUOTE
-			if(str[x+1] === '\'') {
-				result+= '\\\\\'';
+		} else if (str[x] === '\\' && (str[x + 1] === '\'' || str[x + 1] === '"')) {
+			// IF ESCAPE CHARACTER IS FOUND AND DOUBLE OR SINGLE QUOTE AFTER
+			// ESCAPE + SINGLE QUOTE
+			if (str[x + 1] === '\'') {
+				result += '\\\\\'';
 				x++;
-			}
-			//ESCAPE + DOUBLE QUOTE
-			else if(str[x+1] === '"') {
-				result+= '"';
+			} else if (str[x + 1] === '"') {
+				// ESCAPE + DOUBLE QUOTE
+				result += '"';
 				x++;
+			}			else				{
+				result += str[x];
 			}
-			else
-				result+= str[x];
-		}
-		//BACKSLASHES --> DON'T TOUCHE THEM
-		else if(str[x] === '\\' && str[x+1] === '\\') {
-			result+='\\\\';
+		}		else if (str[x] === '\\' && str[x + 1] === '\\') {
+			// BACKSLASHES --> DON'T TOUCHE THEM
+			result += '\\\\';
 			x++;
+		}		else			{
+			result += str[x];
 		}
-		else
-			result+= str[x];
 	}
 	return result;
 };

--- a/index.js
+++ b/index.js
@@ -1,19 +1,18 @@
 'use strict';
 module.exports = function (str) {
 	var result = '';
-	var x;
-	var len = str.length;
+	var i;
 	var betweenQuotes = false;
 	var quoteChar;
-	for (x = 0; x < len; x++) {
+	for (i = 0; i < str.length; i++) {
 		// found double-quote or single-quote
-		if (str[x] === '"' || str[x] === '\'') {
+		if (str[i] === '"' || str[i] === '\'') {
 			// if not processing in between quotes
 			if (!betweenQuotes) {
-				quoteChar = str[x];
+				quoteChar = str[i];
 				betweenQuotes = true;
 				result += '\'';
-			} else if (quoteChar === str[x]) {
+			} else if (quoteChar === str[i]) {
 				// if processing between quotes
 				// close quotes
 				result += '\'';
@@ -22,25 +21,25 @@ module.exports = function (str) {
 				// still inside quotes
 				result += '\\\'';
 			}
-		} else if (str[x] === '\\' && (str[x + 1] === '\'' || str[x + 1] === '"')) {
+		} else if (str[i] === '\\' && (str[i + 1] === '\'' || str[i + 1] === '"')) {
 			// if escape character is found and double or single quote after
 			// escape + single-quote
-			if (str[x + 1] === '\'') {
+			if (str[i + 1] === '\'') {
 				result += '\\\\\'';
-				x++;
-			} else if (str[x + 1] === '"') {
+				i++;
+			} else if (str[i + 1] === '"') {
 				// escape + double-quote
 				result += '"';
-				x++;
+				i++;
 			} else {
-				result += str[x];
+				result += str[i];
 			}
-		} else if (str[x] === '\\' && str[x + 1] === '\\') {
-			// backslashes --> don't touch them
+		} else if (str[i] === '\\' && str[i + 1] === '\\') {
+			// don't touch backslashes
 			result += '\\\\';
-			x++;
+			i++;
 		} else {
-			result += str[x];
+			result += str[i];
 		}
 	}
 	return result;

--- a/test.js
+++ b/test.js
@@ -12,11 +12,11 @@ test('convert matching double-quotes to single-quotes', t => {
 	t.is(m('bar "foo" baz'), 'bar \'foo\' baz');
 	t.is(m('\'bar\' "foo" \'baz\''), '\'bar\' \'foo\' \'baz\'');
 	t.is(m(JSON.stringify({a: '<a href="addr">'})), '{\'a\':\'<a href="addr">\'}');
-	/*t.is(m(JSON.stringify({a: 'aa\n<a href="addr">'})), '{\'a\':\'aa\\n<a href="addr">\'}');
-	t.is(m(JSON.stringify({a: 'b\'\'c'})), '{\'a\':\'b\\\'\\\'c\'}');*/
+	t.is(m(JSON.stringify({a: 'aa\n<a href="addr">'})), '{\'a\':\'aa\\n<a href="addr">\'}');
+	t.is(m(JSON.stringify({a: 'b\'\'c'})), '{\'a\':\'b\\\'\\\'c\'}');
 });
 
-/*test('convert matching double-quotes to single-quotes but do not touch escaped backslashes', t => {
+test('convert matching double-quotes to single-quotes but do not touch escaped backslashes', t => {
 	t.is(m(fs.readFileSync('fixtures/dont-touch-escaped-backslashes/fixture.txt', 'utf8')), fs.readFileSync('fixtures/dont-touch-escaped-backslashes/expected.txt', 'utf8'));
 });
 
@@ -26,4 +26,4 @@ test('convert matching double-quotes to single-quotes despite backslashes', t =>
 	t.is(m('"\\\\\'"'), '\'\\\\\\\'\'', 'Double backslash');
 	t.is(m('"\\\\\' \\\\\'"'), '\'\\\\\\\' \\\\\\\'\'', 'Repetition');
 	t.is(m('"\\\\n \\\\\'"'), '\'\\\\n \\\\\\\'\'', 'With another backslash character');
-});*/
+});

--- a/test.js
+++ b/test.js
@@ -12,11 +12,11 @@ test('convert matching double-quotes to single-quotes', t => {
 	t.is(m('bar "foo" baz'), 'bar \'foo\' baz');
 	t.is(m('\'bar\' "foo" \'baz\''), '\'bar\' \'foo\' \'baz\'');
 	t.is(m(JSON.stringify({a: '<a href="addr">'})), '{\'a\':\'<a href="addr">\'}');
-	t.is(m(JSON.stringify({a: 'aa\n<a href="addr">'})), '{\'a\':\'aa\\n<a href="addr">\'}');
-	t.is(m(JSON.stringify({a: 'b\'\'c'})), '{\'a\':\'b\\\'\\\'c\'}');
+	/*t.is(m(JSON.stringify({a: 'aa\n<a href="addr">'})), '{\'a\':\'aa\\n<a href="addr">\'}');
+	t.is(m(JSON.stringify({a: 'b\'\'c'})), '{\'a\':\'b\\\'\\\'c\'}');*/
 });
 
-test('convert matching double-quotes to single-quotes but do not touch escaped backslashes', t => {
+/*test('convert matching double-quotes to single-quotes but do not touch escaped backslashes', t => {
 	t.is(m(fs.readFileSync('fixtures/dont-touch-escaped-backslashes/fixture.txt', 'utf8')), fs.readFileSync('fixtures/dont-touch-escaped-backslashes/expected.txt', 'utf8'));
 });
 
@@ -26,4 +26,4 @@ test('convert matching double-quotes to single-quotes despite backslashes', t =>
 	t.is(m('"\\\\\'"'), '\'\\\\\\\'\'', 'Double backslash');
 	t.is(m('"\\\\\' \\\\\'"'), '\'\\\\\\\' \\\\\\\'\'', 'Repetition');
 	t.is(m('"\\\\n \\\\\'"'), '\'\\\\n \\\\\\\'\'', 'With another backslash character');
-});
+});*/


### PR DESCRIPTION
I saw this issue and decided to fork and give it a try, mainly because regular expressions can become really messy and confusing especially if things scale. The string processing suggested by you, was definitely a good idea to straighten things up.

The solution that I found for this problem was to iterate through the string maintaining a state, which is defined by the betweenQuotes variable. It is used to know when the processing is happening between two matching quotes and when the closing quote is found. While processing between matching quotes, escape and backslashes characters are processed in order to know when to escape a single quote or simply to escape the backslash.

What do you guys think?
Any suggestions?! Feel free to give me your advice. 

TODO:

- [ ] It would be interesting to add options in order to make the other way possible (single quotes -> double quotes).

---

Fixes #13