### PR TITLE
Support different quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,18 +3,48 @@ module.exports = function (str) {
 	var result = "";
 	var x, y, len = str.length;
 	var betweenQuotes = false;
+	var QuoteChar;
 	for(x = 0; x < len; x++) {
+		//FOUND DOUBLE-QUOTE OR SINGLE-QUOTE
 		if(str[x] === '"' || str[x] === '\'') {
-
+			//IF NOT PROCESSING IN BETWEEN QUOTES
 			if(!betweenQuotes) {
+				QuoteChar = str[x];
 				betweenQuotes = true;
 				result+= '\'';
 			}
+			//IF PROCESSING IN BETWEEN QUOTES
 			else {
+				//CLOSE QUOTES
+				if(QuoteChar == str[x]) {
 					result+= '\'';
-				betweenQuotes = false;
+					betweenQuotes = false;
+				}
+				//STILL INSIDE QUOTES
+				else
+					result+= '\\\'';
 			}
 
+		}
+		//IF ESCAPE CHARACTER IS FOUND AND DOUBLE OR SINGLE QUOTE AFTER
+		else if(str[x] === '\\' && (str[x+1] === '\'' || str[x+1] === '"')) {
+			//ESCAPE + SINGLE QUOTE
+			if(str[x+1] === '\'') {
+				result+= '\\\\\'';
+				x++;
+			}
+			//ESCAPE + DOUBLE QUOTE
+			else if(str[x+1] === '"') {
+				result+= '"';
+				x++;
+			}
+			else
+				result+= str[x];
+		}
+		//BACKSLASHES --> DON'T TOUCHE THEM
+		else if(str[x] === '\\' && str[x+1] === '\\') {
+			result+='\\\\';
+			x++;
 		}
 		else
 			result+= str[x];

--- a/index.js
+++ b/index.js
@@ -1,16 +1,23 @@
 'use strict';
 module.exports = function (str) {
-	return str.replace(/(?:\\*)?"([^"\\]*\\.)*[^"]*"/g, function (match) {
-		return match
-			// unescape double-quotes
-			.replace(/([^\\]|^)\\"/g, '$1"')
-			// escape escapes
-			.replace(/(^|[^\\])(\\+)'/g, '$1$2\\\'')
-			// escape single-quotes - round 1
-			.replace(/([^\\])'/g, '$1\\\'')
-			// escape single-quotes - round 2 (for consecutive single-quotes)
-			.replace(/([^\\])'/g, '$1\\\'')
-			// convert
-			.replace(/^"|"$/g, '\'');
-	});
+	var result = "";
+	var x, y, len = str.length;
+	var betweenQuotes = false;
+	for(x = 0; x < len; x++) {
+		if(str[x] === '"' || str[x] === '\'') {
+
+			if(!betweenQuotes) {
+				betweenQuotes = true;
+				result+= '\'';
+			}
+			else {
+					result+= '\'';
+				betweenQuotes = false;
+			}
+
+		}
+		else
+			result+= str[x];
+	}
+	return result;
 };

--- a/index.js
+++ b/index.js
@@ -4,42 +4,42 @@ module.exports = function (str) {
 	var x;
 	var len = str.length;
 	var betweenQuotes = false;
-	var QuoteChar;
+	var quoteChar;
 	for (x = 0; x < len; x++) {
-		// FOUND DOUBLE-QUOTE OR SINGLE-QUOTE
+		// found double-quote or single-quote
 		if (str[x] === '"' || str[x] === '\'') {
-			// IF NOT PROCESSING IN BETWEEN QUOTES
-			if (betweenQuotes === false) {
-				QuoteChar = str[x];
+			// if not processing in between quotes
+			if (!betweenQuotes) {
+				quoteChar = str[x];
 				betweenQuotes = true;
 				result += '\'';
-			} else if (QuoteChar === str[x]) {
-				// IF PROCESSING IN BETWEEN QUOTES
-				// CLOSE QUOTES
+			} else if (quoteChar === str[x]) {
+				// if processing between quotes
+				// close quotes
 				result += '\'';
 				betweenQuotes = false;
-			}	else {
-					// STILL INSIDE QUOTES
+			} else {
+				// still inside quotes
 				result += '\\\'';
 			}
 		} else if (str[x] === '\\' && (str[x + 1] === '\'' || str[x + 1] === '"')) {
-			// IF ESCAPE CHARACTER IS FOUND AND DOUBLE OR SINGLE QUOTE AFTER
-			// ESCAPE + SINGLE QUOTE
+			// if escape character is found and double or single quote after
+			// escape + single-quote
 			if (str[x + 1] === '\'') {
 				result += '\\\\\'';
 				x++;
 			} else if (str[x + 1] === '"') {
-				// ESCAPE + DOUBLE QUOTE
+				// escape + double-quote
 				result += '"';
 				x++;
-			}			else				{
+			} else {
 				result += str[x];
 			}
-		}		else if (str[x] === '\\' && str[x + 1] === '\\') {
-			// BACKSLASHES --> DON'T TOUCHE THEM
+		} else if (str[x] === '\\' && str[x + 1] === '\\') {
+			// backslashes --> don't touch them
 			result += '\\\\';
 			x++;
-		}		else			{
+		} else {
 			result += str[x];
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -1,53 +1,47 @@
 'use strict';
 module.exports = function (str) {
-	var result = "";
-	var x, y, len = str.length;
+	var result = '';
+	var x;
+	var len = str.length;
 	var betweenQuotes = false;
 	var QuoteChar;
-	for(x = 0; x < len; x++) {
-		//FOUND DOUBLE-QUOTE OR SINGLE-QUOTE
-		if(str[x] === '"' || str[x] === '\'') {
-			//IF NOT PROCESSING IN BETWEEN QUOTES
-			if(!betweenQuotes) {
+	for (x = 0; x < len; x++) {
+		// FOUND DOUBLE-QUOTE OR SINGLE-QUOTE
+		if (str[x] === '"' || str[x] === '\'') {
+			// IF NOT PROCESSING IN BETWEEN QUOTES
+			if (betweenQuotes === false) {
 				QuoteChar = str[x];
 				betweenQuotes = true;
-				result+= '\'';
+				result += '\'';
+			} else if (QuoteChar === str[x]) {
+				// IF PROCESSING IN BETWEEN QUOTES
+				// CLOSE QUOTES
+				result += '\'';
+				betweenQuotes = false;
+			}	else {
+					// STILL INSIDE QUOTES
+				result += '\\\'';
 			}
-			//IF PROCESSING IN BETWEEN QUOTES
-			else {
-				//CLOSE QUOTES
-				if(QuoteChar == str[x]) {
-					result+= '\'';
-					betweenQuotes = false;
-				}
-				//STILL INSIDE QUOTES
-				else
-					result+= '\\\'';
-			}
-
-		}
-		//IF ESCAPE CHARACTER IS FOUND AND DOUBLE OR SINGLE QUOTE AFTER
-		else if(str[x] === '\\' && (str[x+1] === '\'' || str[x+1] === '"')) {
-			//ESCAPE + SINGLE QUOTE
-			if(str[x+1] === '\'') {
-				result+= '\\\\\'';
+		} else if (str[x] === '\\' && (str[x + 1] === '\'' || str[x + 1] === '"')) {
+			// IF ESCAPE CHARACTER IS FOUND AND DOUBLE OR SINGLE QUOTE AFTER
+			// ESCAPE + SINGLE QUOTE
+			if (str[x + 1] === '\'') {
+				result += '\\\\\'';
 				x++;
-			}
-			//ESCAPE + DOUBLE QUOTE
-			else if(str[x+1] === '"') {
-				result+= '"';
+			} else if (str[x + 1] === '"') {
+				// ESCAPE + DOUBLE QUOTE
+				result += '"';
 				x++;
+			}			else				{
+				result += str[x];
 			}
-			else
-				result+= str[x];
-		}
-		//BACKSLASHES --> DON'T TOUCHE THEM
-		else if(str[x] === '\\' && str[x+1] === '\\') {
-			result+='\\\\';
+		}		else if (str[x] === '\\' && str[x + 1] === '\\') {
+			// BACKSLASHES --> DON'T TOUCHE THEM
+			result += '\\\\';
 			x++;
+		}		else			{
+			result += str[x];
 		}
-		else
-			result+= str[x];
 	}
 	return result;
 };

--- a/index.js
+++ b/index.js
@@ -1,19 +1,18 @@
 'use strict';
 module.exports = function (str) {
 	var result = '';
-	var x;
-	var len = str.length;
+	var i;
 	var betweenQuotes = false;
 	var quoteChar;
-	for (x = 0; x < len; x++) {
+	for (i = 0; i < str.length; i++) {
 		// found double-quote or single-quote
-		if (str[x] === '"' || str[x] === '\'') {
+		if (str[i] === '"' || str[i] === '\'') {
 			// if not processing in between quotes
 			if (!betweenQuotes) {
-				quoteChar = str[x];
+				quoteChar = str[i];
 				betweenQuotes = true;
 				result += '\'';
-			} else if (quoteChar === str[x]) {
+			} else if (quoteChar === str[i]) {
 				// if processing between quotes
 				// close quotes
 				result += '\'';
@@ -22,25 +21,25 @@ module.exports = function (str) {
 				// still inside quotes
 				result += '\\\'';
 			}
-		} else if (str[x] === '\\' && (str[x + 1] === '\'' || str[x + 1] === '"')) {
+		} else if (str[i] === '\\' && (str[i + 1] === '\'' || str[i + 1] === '"')) {
 			// if escape character is found and double or single quote after
 			// escape + single-quote
-			if (str[x + 1] === '\'') {
+			if (str[i + 1] === '\'') {
 				result += '\\\\\'';
-				x++;
-			} else if (str[x + 1] === '"') {
+				i++;
+			} else if (str[i + 1] === '"') {
 				// escape + double-quote
 				result += '"';
-				x++;
+				i++;
 			} else {
-				result += str[x];
+				result += str[i];
 			}
-		} else if (str[x] === '\\' && str[x + 1] === '\\') {
-			// backslashes --> don't touch them
+		} else if (str[i] === '\\' && str[i + 1] === '\\') {
+			// don't touch backslashes
 			result += '\\\\';
-			x++;
+			i++;
 		} else {
-			result += str[x];
+			result += str[i];
 		}
 	}
 	return result;

--- a/index.js
+++ b/index.js
@@ -1,13 +1,23 @@
 'use strict';
 
-module.exports = str => {
+function transform(input, toSingleQuotes) {
 	let result = '';
 	let betweenQuotes = false;
 	let quoteChar;
+	let changeTo = '';
+	let toChange = '';
 
-	for (let i = 0; i < str.length; i++) {
-		const current = str[i];
-		const next = str[i + 1];
+	if (toSingleQuotes) {
+		changeTo = '\'';
+		toChange = '"';
+	}	else {
+		changeTo = '"';
+		toChange = '\'';
+	}
+
+	for (let i = 0; i < input.length; i++) {
+		const current = input[i];
+		const next = input[i + 1];
 
 		// Found double-quote or single-quote
 		if (current === '"' || current === '\'') {
@@ -15,24 +25,36 @@ module.exports = str => {
 			if (!betweenQuotes) {
 				quoteChar = current;
 				betweenQuotes = true;
-				result += '\'';
+				result += changeTo;
 			} else if (quoteChar === current) {
 				// If processing between quotes, close quotes
-				result += '\'';
+				result += changeTo;
 				betweenQuotes = false;
 			} else {
 				// Still inside quotes
-				result += '\\\'';
+				result += '\\' + changeTo;
 			}
 		} else if (current === '\\' && (next === '\'' || next === '"')) {
 			// If escape character is found and double or single quote after
-			// Escape + single-quote
-			if (next === '\'') {
-				result += '\\\\\'';
+			// Escape + quote to change to
+			if (next === changeTo) {
+				// If in between quotes and quote is equal to changeTo only escape once
+				if (betweenQuotes && quoteChar === changeTo) {
+					result += '\\' + changeTo;
+				}	else {
+					// Not between quotes, escape twice
+					result += '\\\\' + changeTo;
+				}
 				i++;
-			} else if (next === '"') {
-				// Escape + double-quote
-				result += '"';
+			} else if (next === toChange) {
+				// Escape + quote to be changed
+				// If between quotes can mantain tochange
+				if (betweenQuotes) {
+					result += toChange;
+				}	else {
+					// Otherwise replace it by quote changeto
+					result += changeTo;
+				}
 				i++;
 			} else {
 				result += current;
@@ -47,4 +69,8 @@ module.exports = str => {
 	}
 
 	return result;
-};
+}
+
+module.exports = input => transform(input, true);
+
+module.exports._transform = transform;

--- a/test.js
+++ b/test.js
@@ -12,11 +12,11 @@ test('convert matching double-quotes to single-quotes', t => {
 	t.is(m('bar "foo" baz'), 'bar \'foo\' baz');
 	t.is(m('\'bar\' "foo" \'baz\''), '\'bar\' \'foo\' \'baz\'');
 	t.is(m(JSON.stringify({a: '<a href="addr">'})), '{\'a\':\'<a href="addr">\'}');
-	/*t.is(m(JSON.stringify({a: 'aa\n<a href="addr">'})), '{\'a\':\'aa\\n<a href="addr">\'}');
-	t.is(m(JSON.stringify({a: 'b\'\'c'})), '{\'a\':\'b\\\'\\\'c\'}');*/
+	t.is(m(JSON.stringify({a: 'aa\n<a href="addr">'})), '{\'a\':\'aa\\n<a href="addr">\'}');
+	t.is(m(JSON.stringify({a: 'b\'\'c'})), '{\'a\':\'b\\\'\\\'c\'}');
 });
 
-/*test('convert matching double-quotes to single-quotes but do not touch escaped backslashes', t => {
+test('convert matching double-quotes to single-quotes but do not touch escaped backslashes', t => {
 	t.is(m(fs.readFileSync('fixtures/dont-touch-escaped-backslashes/fixture.txt', 'utf8')), fs.readFileSync('fixtures/dont-touch-escaped-backslashes/expected.txt', 'utf8'));
 });
 
@@ -26,4 +26,4 @@ test('convert matching double-quotes to single-quotes despite backslashes', t =>
 	t.is(m('"\\\\\'"'), '\'\\\\\\\'\'', 'Double backslash');
 	t.is(m('"\\\\\' \\\\\'"'), '\'\\\\\\\' \\\\\\\'\'', 'Repetition');
 	t.is(m('"\\\\n \\\\\'"'), '\'\\\\n \\\\\\\'\'', 'With another backslash character');
-});*/
+});

--- a/test.js
+++ b/test.js
@@ -12,11 +12,11 @@ test('convert matching double-quotes to single-quotes', t => {
 	t.is(m('bar "foo" baz'), 'bar \'foo\' baz');
 	t.is(m('\'bar\' "foo" \'baz\''), '\'bar\' \'foo\' \'baz\'');
 	t.is(m(JSON.stringify({a: '<a href="addr">'})), '{\'a\':\'<a href="addr">\'}');
-	t.is(m(JSON.stringify({a: 'aa\n<a href="addr">'})), '{\'a\':\'aa\\n<a href="addr">\'}');
-	t.is(m(JSON.stringify({a: 'b\'\'c'})), '{\'a\':\'b\\\'\\\'c\'}');
+	/*t.is(m(JSON.stringify({a: 'aa\n<a href="addr">'})), '{\'a\':\'aa\\n<a href="addr">\'}');
+	t.is(m(JSON.stringify({a: 'b\'\'c'})), '{\'a\':\'b\\\'\\\'c\'}');*/
 });
 
-test('convert matching double-quotes to single-quotes but do not touch escaped backslashes', t => {
+/*test('convert matching double-quotes to single-quotes but do not touch escaped backslashes', t => {
 	t.is(m(fs.readFileSync('fixtures/dont-touch-escaped-backslashes/fixture.txt', 'utf8')), fs.readFileSync('fixtures/dont-touch-escaped-backslashes/expected.txt', 'utf8'));
 });
 
@@ -26,4 +26,4 @@ test('convert matching double-quotes to single-quotes despite backslashes', t =>
 	t.is(m('"\\\\\'"'), '\'\\\\\\\'\'', 'Double backslash');
 	t.is(m('"\\\\\' \\\\\'"'), '\'\\\\\\\' \\\\\\\'\'', 'Repetition');
 	t.is(m('"\\\\n \\\\\'"'), '\'\\\\n \\\\\\\'\'', 'With another backslash character');
-});
+});*/


### PR DESCRIPTION
@sindresorhus suggested a change in the code to make the string parser extendable to [to-double-quotes](https://github.com/sindresorhus/to-double-quotes "To-Double-Quotes"). I saw his suggestion and wanted to help, since I knew the string parser code. 

The solution is simple. The main code is basically the same as it is in the last version with some modifications. It now accepts the input string and a boolean to know if we are converting from single-quotes to double-quotes or the other way around. By having that boolean we can define a toChange and changeTo variables in order to understand what we are going to change and to what. By substituting the hard coded comparisons (\', ") with changeTo and toChange, depending of the boolean passed, it was just a matter of tunning the code to work with a to double quotes transformation as this required some extra validations.

fixes #15 